### PR TITLE
Cache DiGraph objects

### DIFF
--- a/environment_tools/type_utils.py
+++ b/environment_tools/type_utils.py
@@ -6,9 +6,27 @@ from environment_tools.config import _read_data_json
 from environment_tools.config import _convert_mapping_to_graph
 
 
-def location_graph():
+# See https://github.com/Yelp/environment_tools/issues/2, for reasons that
+# are unclear, creating the DiGraph on every call to this function has
+# been observed to cause application memory leaks. It's probably wrong to
+# do this work on every call to location_graph anyways, so let's just cache it
+# This cache takes the form of a tuple(dict, DiGraph) so that if the json
+# changes we can invalidate the cache immediately.
+_location_graph_cache = (None, None)
+
+
+def location_graph(use_cache=True):
+    global _location_graph_cache
+
     location_mapping = _read_data_json('location_mapping.json')
-    return _convert_mapping_to_graph(location_mapping)
+    if not use_cache:
+        return _convert_mapping_to_graph(location_mapping)
+
+    if (_location_graph_cache[0] != location_mapping):
+        _location_graph_cache = (
+            location_mapping, _convert_mapping_to_graph(location_mapping)
+        )
+    return _location_graph_cache[1]
 
 
 def available_location_types():

--- a/environment_tools/type_utils.py
+++ b/environment_tools/type_utils.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from collections import namedtuple
 import os
 import networkx as nx
 
@@ -12,7 +13,8 @@ from environment_tools.config import _convert_mapping_to_graph
 # do this work on every call to location_graph anyways, so let's just cache it
 # This cache takes the form of a tuple(dict, DiGraph) so that if the json
 # changes we can invalidate the cache immediately.
-_location_graph_cache = (None, None)
+GraphCache = namedtuple('GraphCache', ('source', 'graph'))
+_location_graph_cache = GraphCache(None, None)
 
 
 def location_graph(use_cache=True):
@@ -22,11 +24,12 @@ def location_graph(use_cache=True):
     if not use_cache:
         return _convert_mapping_to_graph(location_mapping)
 
-    if (_location_graph_cache[0] != location_mapping):
-        _location_graph_cache = (
-            location_mapping, _convert_mapping_to_graph(location_mapping)
+    if (_location_graph_cache.source != location_mapping):
+        _location_graph_cache = GraphCache(
+            source=location_mapping,
+            graph=_convert_mapping_to_graph(location_mapping)
         )
-    return _location_graph_cache[1]
+    return _location_graph_cache.graph
 
 
 def available_location_types():

--- a/tests/test_type_utils.py
+++ b/tests/test_type_utils.py
@@ -44,9 +44,10 @@ class TestTypeUtils:
         }
         with mock.patch('environment_tools.type_utils._read_data_json',
                         side_effect=fake_data.get) as mock_fake_data:
-            environment_tools.type_utils._location_graph_cache = (None, None)
+            empty_graph = environment_tools.type_utils.GraphCache(None, None)
+            environment_tools.type_utils._location_graph_cache = empty_graph
             yield mock_fake_data
-            environment_tools.type_utils._location_graph_cache = (None, None)
+            environment_tools.type_utils._location_graph_cache = empty_graph
 
     def test_location_graph_cache(self, mock_data):
         mock_convert = mock.Mock(spec=_convert_mapping_to_graph)

--- a/tests/test_type_utils.py
+++ b/tests/test_type_utils.py
@@ -3,10 +3,13 @@
 import contextlib
 import mock
 
+from environment_tools.config import _convert_mapping_to_graph
+import environment_tools.type_utils
 from environment_tools.type_utils import available_location_types
 from environment_tools.type_utils import convert_location_type
 from environment_tools.type_utils import compare_types
 from environment_tools.type_utils import get_current_location
+from environment_tools.type_utils import location_graph
 
 from types import ListType
 from types import StringType
@@ -41,7 +44,21 @@ class TestTypeUtils:
         }
         with mock.patch('environment_tools.type_utils._read_data_json',
                         side_effect=fake_data.get) as mock_fake_data:
+            environment_tools.type_utils._location_graph_cache = (None, None)
             yield mock_fake_data
+            environment_tools.type_utils._location_graph_cache = (None, None)
+
+    def test_location_graph_cache(self, mock_data):
+        mock_convert = mock.Mock(spec=_convert_mapping_to_graph)
+        mock_convert.return_value = 'fake_graph'
+        with mock.patch(
+                'environment_tools.type_utils._convert_mapping_to_graph',
+                mock_convert):
+            for i in range(5):
+                assert location_graph() == 'fake_graph'
+            assert mock_convert.call_count == 1
+            assert location_graph(use_cache=False) == 'fake_graph'
+            assert mock_convert.call_count == 2
 
     def test_available_location_types(self, mock_data):
         location_types = available_location_types()

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist = py26,py27,py34
 [testenv]
 deps =
     -rrequirements-dev.txt
-    flake8
+    flake8<2.999
     coverage
 
 commands =


### PR DESCRIPTION
Attempts to mitigate #2 

I'm not convinced that a global is the best way to do this, but it does seem to be the most concise. Alternative options:

- Make a class to hold the state
- Import some kind of memoization library (probably the LRU cache backport from python 3)

Note that this does mean that we "leak" exactly one instance of the DiGraph intentionally, but ... we're showing like 100megs saved per worker on Apollo so that's reasonable I think.