### PR TITLE
Drop python2.6, simplify packaging

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,30 @@
+[run]
+branch = True
+source =
+    .
+omit =
+    .tox/*
+    /usr/*
+    */tmp*
+    setup.py
+    # Don't complain if non-runnable code isn't run
+    */__main__.py
+
+[report]
+exclude_lines =
+    # Have to re-enable the standard pragma
+    \#\s*pragma: no cover
+
+    # Don't complain if tests don't hit defensive assertion code:
+    ^\s*raise AssertionError\b
+    ^\s*raise NotImplementedError\b
+    ^\s*return NotImplemented\b
+    ^\s*raise$
+
+    # Don't complain if non-runnable code isn't run:
+    ^if __name__ == ['"]__main__['"]:$
+
+[html]
+directory = coverage-html
+
+# vim:ft=dosini

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,7 @@
 language: python
-# We use the built-in tox matrix capabilities instead of matrixing on different
-# python versions directly.
-python:
-  - 2.7
-install:
-  - pip install tox
-script:
-  - tox
+python: 3.5
 env:
-  - TOXENV=py26
   - TOXENV=py27
-  - TOXENV=py34
+  - TOXENV=py35
+install: pip install tox
+script: tox

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,0 @@
-recursive-include environment_tools/data *

--- a/environment_tools/config.py
+++ b/environment_tools/config.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
+import json
 import os
-
-import simplejson as json
 
 import networkx as nx
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,5 @@
--rrequirements.txt
+coverage
+flake8
 mock
 pytest
 six

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,0 @@
-# The -e . syntax means to install the package in this directory as well.
--e .

--- a/setup.py
+++ b/setup.py
@@ -10,15 +10,6 @@ setup(
     version=version,
     description='Utilities for working with hierarchical environments',
     packages=['environment_tools'],
-    setup_requires=['setuptools'],
-    install_requires=[
-        'argparse >= 1.2.1',
-        'simplejson >= 2.1.0',
-        'networkx == 1.9.1',
-    ],
-    entry_points={
-        'console_scripts': []
-    },
+    install_requires=['networkx >= 1.9.1'],
     license='Copyright Yelp 2015, All Rights Reserved',
-    include_package_data=True
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,24 +1,21 @@
 [tox]
-envlist = py26,py27,py34
+envlist = py27,py35
 
 [testenv]
-deps =
-    -rrequirements-dev.txt
-    flake8<2.999
-    coverage
-
+deps = -rrequirements-dev.txt
 commands =
     coverage erase
     coverage run -m py.test {posargs:tests}
-    coverage report --omit=.tox/*,tests/*,packages/*,/usr/share/pyshared/*,/usr/lib/pymodules/* -m
+    coverage report -m
     flake8 environment_tools tests setup.py
 
 [testenv:devenv]
+basepython = /usr/bin/python2.7
 envdir = virtualenv_run
 commands =
 
 [testenv:docs]
-deps =
-    sphinx
+basepython = /usr/bin/python2.7
+deps = sphinx
 changedir = docs
 commands = sphinx-build -b html -d build/doctrees source build/html


### PR DESCRIPTION
```diff
+py35
+coveragerc
-py26
-environment_tools.data (nothing in there)
-requirements.txt (not an application)
-pinning in setup.py (not an application)
-simplejson (json is now in C in py27+)
```