### PR TITLE
Support working with locations along with location types

### DIFF
--- a/environment_tools/node_utils.py
+++ b/environment_tools/node_utils.py
@@ -1,0 +1,79 @@
+# -*- coding: utf-8 -*-
+import re
+
+from environment_tools import type_utils
+
+NODE_NAME_FORMAT = '[A-Za-z0-9]*(-[A-Za-z0-9]*)*-(?P<location>[A-Za-z0-9]*)($|\..*)'
+
+
+def get_node_location(node, name_format=NODE_NAME_FORMAT):
+    """ Parses the node location from the provided node hostname.
+
+    :param node: A string that reprsents the node's hostname eg "my-machine-devb.place.com"
+    :param name_format: A string that represents the regex to parse the node's location from
+        the full hostname. Must have the capture group 'location' defined to correctly parse
+        the location.
+    :returns: node_location, The location of the given hostname or None if not found.
+    :rtype: String or None
+    """
+    matches = re.search(name_format, node)
+    if not matches:
+        return None
+    else:
+        node_location = matches.group('location')
+        return node_location
+
+
+def get_node_location_type(node_location):
+    """ Given a node location returns the location_type of that node.
+
+    For example:
+       Assume type_utils.available_location_types() is ['ecosystem', 'region', 'habitat'],
+       and the location graph is:
+        - prod
+          - uswest1-prod
+            - uswest1aprod
+            - uswest1bprod
+
+        get_node_location('uswest1aprod') -> 'habitat'
+        get_node_location('uswest1-prod') -> 'region'
+
+    :param node_location: A string that represents a node's location
+    :returns: location_type, The location type that corresponds to that node's location.
+    :rtype: String
+    """
+    location_graph = type_utils.location_graph()
+    for location_type in type_utils.available_location_types():
+        if location_graph.has_node('{}_{}'.format(node_location, location_type)):
+            return location_type
+    raise ValueError('{} not found in environment'.format(node_location))
+
+
+def node_location_equality(node_1, node_2, location_type):
+    """ Checks if two nodes are equal for a specific location type.
+
+    For example:
+       Assume type_utils.available_location_types() is ['ecosystem', 'region', 'habitat'],
+       and the location graph is:
+        - prod
+          - uswest1-prod
+            - uswest1aprod
+            - uswest1bprod
+
+        node_location_equality('uswest1aprod', uswest1bprod', 'habitat') -> False
+        node_location_equality('uswest1aprod', uswest1bprod', 'region') -> True
+
+    :param node_1: A string that represents a node
+    :param node_2: A string that represents a node
+    :param location_type: A string that represents the location_type to use to compare the
+        two nodes.
+    :returns: True or False.
+    :rtype: bool
+    """
+    node_1_location_type = get_node_location_type(node_1)
+    if node_1_location_type != location_type:
+        node_1 = type_utils.convert_location_type(node_1, node_1_location_type, location_type)
+    node_2_location_type = get_node_location_type(node_2)
+    if node_2_location_type != location_type:
+        node_2 = type_utils.convert_location_type(node_2, node_2_location_type, location_type)
+    return node_1 == node_2

--- a/tests/test_node_utils.py
+++ b/tests/test_node_utils.py
@@ -1,0 +1,84 @@
+# -*- coding: utf-8 -*-
+import mock
+import pytest
+
+from environment_tools import node_utils
+from environment_tools import type_utils
+
+
+@pytest.yield_fixture
+def mock_data():
+    fake_data = {
+        'location_types.json': ['environment', 'region', 'az'],
+        'location_mapping.json': {
+            'prod_environment': {
+                'usnorth1-prod_region': {
+                    'usnorth1aprod_az': {},
+                    'usnorth1bprod_az': {},
+                },
+                'usnorth2-prod_region': {
+                    'usnorth2aprod_az': {},
+                    'usnorth2bprod_az': {},
+                    'usnorth2cprod_az': {},
+                },
+            },
+            'dev_environment': {
+                'usnorth1-dev_region': {
+                    'usnorth1adev_az': {},
+                    'usnorth1bdev_az': {},
+                },
+            },
+        },
+    }
+    with mock.patch(
+        'environment_tools.type_utils._read_data_json',
+        side_effect=fake_data.get
+    ) as mock_fake_data:
+        empty_graph = type_utils.GraphCache(None, None)
+        type_utils._location_graph_cache = empty_graph
+        yield mock_fake_data
+        type_utils._location_graph_cache = empty_graph
+
+
+def test_get_node_location():
+    node_hostname = 'my-hostname-usnorth1'
+    assert node_utils.get_node_location(node_hostname) == 'usnorth1'
+
+
+def test_get_node_location_none():
+    node_hostname = 'notahostname'
+    assert node_utils.get_node_location(node_hostname) is None
+
+
+def test_get_node_location_type_az(mock_data):
+    node_location = 'usnorth1adev'
+    assert node_utils.get_node_location_type(node_location) == 'az'
+
+
+def test_get_node_location_type_region(mock_data):
+    node_location = 'usnorth2-prod'
+    assert node_utils.get_node_location_type(node_location) == 'region'
+
+
+def test_get_node_location_type_invalid(mock_data):
+    node_location = 'nananana'
+    with pytest.raises(ValueError):
+        node_utils.get_node_location_type(node_location)
+
+
+def test_node_location_inequaliy_az(mock_data):
+    node_1 = 'usnorth2aprod'
+    node_2 = 'usnorth2bprod'
+    assert node_utils.node_location_equality(node_1, node_2, 'az') is False
+
+
+def test_node_location_equaliy_region(mock_data):
+    node_1 = 'usnorth2aprod'
+    node_2 = 'usnorth2bprod'
+    assert node_utils.node_location_equality(node_1, node_2, 'region') is True
+
+
+def test_node_location_inequaliy_region(mock_data):
+    node_1 = 'usnorth1aprod'
+    node_2 = 'usnorth2bprod'
+    assert node_utils.node_location_equality(node_1, node_2, 'region') is False

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py35
+envlist = py27,py35,py36
 
 [testenv]
 deps = -rrequirements-dev.txt
@@ -19,3 +19,6 @@ basepython = /usr/bin/python2.7
 deps = sphinx
 changedir = docs
 commands = sphinx-build -b html -d build/doctrees source build/html
+
+[flake8]
+max-line-length = 120


### PR DESCRIPTION
Most of the environment_tools functionality supports working with location types, but it doesn't provide much of an API for use with locations. This adds the following functionality:

- Given a hostname + regex string will parse the location.
- Given a location will find the corresponding location type
- Given two locations and a specified location type will determine equality for those locations when converted to that location type.

See function docstrings for examples.

Also upped flake8 line length to 120.