### PR TITLE
Constrain zipp for python3.5 compatibility

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,3 +3,5 @@ flake8
 mock
 pytest
 six
+# For python3.5 compatibility
+zipp<3.1.0


### PR DESCRIPTION
Fixes
```
10:36:43 zipp requires Python '>=3.6' but the running Python is 3.5.2
10:36:43 
10:36:43 ERROR: could not install deps [-rrequirements-dev.txt]; v = InvocationError('/ephemeral/jenkins/workspace/environment_tools-22668/.tox/py35/bin/pip install -rrequirements-dev.txt (see /ephemeral/jenkins/workspace/environment_tools-22668/.tox/py35/log/py35-1.log)', 1)
```