### PR TITLE
Remove `make production` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,7 @@
 
 BIND_FILES ?= undefined
 
-all: production
-
-production:
+all:
 	@true
 
 docs:


### PR DESCRIPTION
This interferes with some internal tooling and isn't really useful anyway.