### PR TITLE
Run tests in supported python 3 versions

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py35
+envlist = py27,py36,py37,py38
 
 [testenv]
 deps = -rrequirements-dev.txt
@@ -10,12 +10,12 @@ commands =
     flake8 environment_tools tests setup.py
 
 [testenv:devenv]
-basepython = /usr/bin/python2.7
+basepython = /usr/bin/python3.8
 envdir = virtualenv_run
 commands =
 
 [testenv:docs]
-basepython = /usr/bin/python2.7
+basepython = /usr/bin/python3.8
 deps = sphinx
 changedir = docs
 commands = sphinx-build -b html -d build/doctrees source build/html

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py36,py37,py38
+envlist = py27,py36,py37
 
 [testenv]
 deps = -rrequirements-dev.txt

--- a/tox.ini
+++ b/tox.ini
@@ -10,12 +10,12 @@ commands =
     flake8 environment_tools tests setup.py
 
 [testenv:devenv]
-basepython = /usr/bin/python3.8
+basepython = /usr/bin/python3.7
 envdir = virtualenv_run
 commands =
 
 [testenv:docs]
-basepython = /usr/bin/python3.8
+basepython = /usr/bin/python3.7
 deps = sphinx
 changedir = docs
 commands = sphinx-build -b html -d build/doctrees source build/html


### PR DESCRIPTION
Python 3.5 reached its end of life on 2020-09-13